### PR TITLE
Feature/total-tickets-overview addition

### DIFF
--- a/src/main/java/org/taskntech/tech_flow/controllers/DashboardController.java
+++ b/src/main/java/org/taskntech/tech_flow/controllers/DashboardController.java
@@ -9,6 +9,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.taskntech.tech_flow.models.ResponseTimeMetrics;
 import org.taskntech.tech_flow.service.TicketService;
 
+import java.util.Map;
+
 @Controller
 @RequestMapping("/dashboard")
 public class DashboardController {
@@ -29,6 +31,13 @@ public class DashboardController {
 
             //Added array list recentActivityLog to view for recent activity
             model.addAttribute("recentActivity", ticketService.recentActivityLog);
+
+            // Fetching ticket counts by priority
+            Map<String, Long> ticketCountByPriority = ticketService.getTicketCountByPriority();
+            model.addAttribute("ticketCountByPriority", ticketCountByPriority);
+            model.addAttribute("highPriorityCount", ticketCountByPriority.getOrDefault("HIGH", 0L));
+            model.addAttribute("mediumPriorityCount", ticketCountByPriority.getOrDefault("MEDIUM", 0L));
+            model.addAttribute("lowPriorityCount", ticketCountByPriority.getOrDefault("LOW", 0L));
 
         return "dashboard";
     }

--- a/src/main/java/org/taskntech/tech_flow/service/TicketService.java
+++ b/src/main/java/org/taskntech/tech_flow/service/TicketService.java
@@ -18,6 +18,9 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 @Service
 public class TicketService {
@@ -446,6 +449,13 @@ public class TicketService {
                 );
         }
 
+        public Map<String, Long> getTicketCountByPriority() {
+                return StreamSupport.stream(ticketRepository.findAll().spliterator(), false)
+                        .collect(Collectors.groupingBy(
+                                ticket -> ticket.getPriority().name(),
+                                Collectors.counting()
+                        ));
+        }
 
 
 }

--- a/src/main/java/org/taskntech/tech_flow/service/TicketService.java
+++ b/src/main/java/org/taskntech/tech_flow/service/TicketService.java
@@ -449,8 +449,10 @@ public class TicketService {
                 );
         }
 
+        // Filters tickets based on their status before grouping by priority. Excludes tickets where the status is marked as "closed" and "resolved".
         public Map<String, Long> getTicketCountByPriority() {
                 return StreamSupport.stream(ticketRepository.findAll().spliterator(), false)
+                        .filter(ticket -> ticket.getStatus() != StatusUpdates.CLOSED && ticket.getStatus() != StatusUpdates.RESOLVED)
                         .collect(Collectors.groupingBy(
                                 ticket -> ticket.getPriority().name(),
                                 Collectors.counting()

--- a/src/main/resources/templates/dashboard.html
+++ b/src/main/resources/templates/dashboard.html
@@ -14,8 +14,25 @@
 
 <div class="flex items-center justify-center space-x-8 pt-8" >
 
-    <!--shapes will go here-->
-    <div class="w-96 h-96 bg-gray-300 p-2 rounded-2xl"></div>
+    <!-- Ticket Priority Overview -->
+    <div class="w-96 h-96 bg-gray-300 p-2 rounded-2xl">
+        <div class="text-2xl py-2 text-center">
+            <p>Active Ticket Priority Overview</p>
+        </div>
+        <div class="flex flex-col space-y-2 p-4">
+            <div class="text-lg bg-white rounded-lg shadow p-4">
+                <p>High: <span th:text="${ticketCountByPriority['HIGH'] ?: 0}"></span> Tickets</p>
+            </div>
+            <div class="text-lg bg-white rounded-lg shadow p-4">
+                <p>Medium: <span th:text="${ticketCountByPriority['MEDIUM'] ?: 0}"></span> Tickets</p>
+            </div>
+            <div class="text-lg bg-white rounded-lg shadow p-4">
+                <p>Low: <span th:text="${ticketCountByPriority['LOW'] ?: 0}"></span> Tickets</p>
+            </div>
+        </div>
+    </div>
+
+    <!-- Keep the second placeholder box -->
     <div class="w-96 h-96 bg-gray-300 p-2 rounded-2xl"></div>
 
     <!-- recent activity -->

--- a/src/main/resources/templates/dashboard.html
+++ b/src/main/resources/templates/dashboard.html
@@ -15,19 +15,28 @@
 <div class="flex items-center justify-center space-x-8 pt-8" >
 
     <!-- Ticket Priority Overview -->
-    <div class="w-96 h-96 bg-gray-300 p-2 rounded-2xl">
+    <div class="w-96 h-96 bg-gray-300 p-4 rounded-2xl">
         <div class="text-2xl py-2 text-center">
-            <p>Active Ticket Priority Overview</p>
+            <p>Open Ticket Priority Overview</p>
         </div>
-        <div class="flex flex-col space-y-2 p-4">
-            <div class="text-lg bg-white rounded-lg shadow p-4">
-                <p>High: <span th:text="${ticketCountByPriority['HIGH'] ?: 0}"></span> Tickets</p>
+        <div class="flex flex-col space-y-3 p-4">
+            <div class="bg-white p-6 rounded-lg shadow flex justify-between items-center">
+                <span class="text-xl font-bold text-black">High:</span>
+                <span class="text-lg font-semibold text-gray-700">
+                <span th:text="${ticketCountByPriority['HIGH'] ?: 0}"></span> Tickets
+            </span>
             </div>
-            <div class="text-lg bg-white rounded-lg shadow p-4">
-                <p>Medium: <span th:text="${ticketCountByPriority['MEDIUM'] ?: 0}"></span> Tickets</p>
+            <div class="bg-white p-6 rounded-lg shadow flex justify-between items-center">
+                <span class="text-xl font-bold text-black">Medium:</span>
+                <span class="text-lg font-semibold text-gray-700">
+                <span th:text="${ticketCountByPriority['MEDIUM'] ?: 0}"></span> Tickets
+            </span>
             </div>
-            <div class="text-lg bg-white rounded-lg shadow p-4">
-                <p>Low: <span th:text="${ticketCountByPriority['LOW'] ?: 0}"></span> Tickets</p>
+            <div class="bg-white p-6 rounded-lg shadow flex justify-between items-center">
+                <span class="text-xl font-bold text-black">Low:</span>
+                <span class="text-lg font-semibold text-gray-700">
+                <span th:text="${ticketCountByPriority['LOW'] ?: 0}"></span> Tickets
+            </span>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Added the "Open Ticket Priority Overview" tile that shows a breakdown of the number of active/open tickets under each priority.
- Updated DashboardController to establish and fetch ticket counts by priority
- Added method to TicketService to filter tickets based on their status before grouping by priority. Excludes tickets where the status is marked as "closed" and "resolved".
- Added "Open Ticket Priority Overview" tile and styling to dashboard.html
