### PR TITLE
uncommented an endpoint registry in WebSocketBrokerConfig

### DIFF
--- a/src/main/java/org/taskntech/tech_flow/config/WebSocketBrokerConfig.java
+++ b/src/main/java/org/taskntech/tech_flow/config/WebSocketBrokerConfig.java
@@ -18,7 +18,7 @@ public class WebSocketBrokerConfig implements WebSocketMessageBrokerConfigurer {
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
-//        registry.addEndpoint("/ws");
+        registry.addEndpoint("/ws");
         registry.addEndpoint("/ws").withSockJS();
     }
 }


### PR DESCRIPTION
originally only the fallback sockJS was included 